### PR TITLE
Add static analysis by Sonar and StyleCop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -192,3 +192,8 @@ src/Orchard.Azure/Orchard.Azure.CloudService/Staging/
 !lib/**/*.*
 **/.vs/*
 src/Rebracer.xml
+
+# =========================
+# Orchard specifics
+# =========================
+.idea

--- a/codeanalysis.ruleset
+++ b/codeanalysis.ruleset
@@ -1,0 +1,77 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<RuleSet Name="Itransition.Net.RuleSet" Description="Code analysis rules for any project" ToolsVersion="15.0">
+  <Include Path="allrules.ruleset" Action="Default" />
+  <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
+    <Rule Id="CA1724" Action="None" />
+    <Rule Id="CA1304" Action="None" />
+    <Rule Id="CA1716" Action="None" />
+    <Rule Id="CA2227" Action="None" />
+    <Rule Id="CA1309" Action="None" />
+    <Rule Id="CA1014" Action="None" />
+    <Rule Id="CA1020" Action="None" />
+    <Rule Id="CA1062" Action="None" />
+    <Rule Id="CA1305" Action="None" />
+    <Rule Id="CA1819" Action="None" />
+    <Rule Id="CA1824" Action="None" />
+    <Rule Id="CA2210" Action="None" />
+    <Rule Id="CA1034" Action="Warning" />
+    <Rule Id="CA1004" Action="Warning" />
+    <Rule Id="CA1006" Action="Warning" />
+    <Rule Id="CA1011" Action="Warning" />
+    <Rule Id="CA1021" Action="Warning" />
+    <Rule Id="CA1024" Action="Warning" />
+    <Rule Id="CA1026" Action="Warning" />
+    <Rule Id="CA1031" Action="Warning" />
+    <Rule Id="CA1032" Action="Warning" />
+    <Rule Id="CA1040" Action="Warning" />
+    <Rule Id="CA1051" Action="Warning" />
+    <Rule Id="CA1302" Action="Warning" />
+    <Rule Id="CA1303" Action="Warning" />
+    <Rule Id="CA1502" Action="Warning" />
+    <Rule Id="CA1504" Action="Warning" />
+    <Rule Id="CA1505" Action="Warning" />
+    <Rule Id="CA1506" Action="Warning" />
+    <Rule Id="CA1702" Action="Warning" />
+    <Rule Id="CA1708" Action="Warning" />
+    <Rule Id="CA1709" Action="Warning" />
+    <Rule Id="CA1800" Action="Warning" />
+    <Rule Id="CA1801" Action="Warning" />
+    <Rule Id="CA1809" Action="Warning" />
+    <Rule Id="CA1810" Action="Warning" />
+    <Rule Id="CA1811" Action="Warning" />
+    <Rule Id="CA1815" Action="Warning" />
+    <Rule Id="CA1816" Action="Warning" />
+    <Rule Id="CA1822" Action="Warning" />
+    <Rule Id="CA2000" Action="Warning" />
+    <Rule Id="CA2002" Action="Warning" />
+    <Rule Id="CA2104" Action="Warning" />
+    <Rule Id="CA2204" Action="Warning" />
+    <Rule Id="CA2215" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.ApiDesignGuidelines.Analyzers" RuleNamespace="Microsoft.ApiDesignGuidelines.Analyzers">
+    <Rule Id="CA2007" Action="Warning" />
+  </Rules>
+  <Rules AnalyzerId="Microsoft.CodeAnalysis.CSharp" RuleNamespace="Microsoft.CodeAnalysis.CSharp">
+    <Rule Id="AD0001" Action="Warning" />
+    <Rule Id="CS1591" Action="Error" />
+  </Rules>
+  <Rules AnalyzerId="StyleCop.Analyzers" RuleNamespace="StyleCop.Analyzers">
+    <Rule Id="SA1652" Action="None" />
+    <Rule Id="SA1407" Action="None" />
+    <Rule Id="SA1122" Action="None" />
+    <Rule Id="SA1204" Action="None" />
+    <Rule Id="SA1202" Action="None" />
+    <Rule Id="SA1101" Action="None" />
+    <Rule Id="SA1201" Action="None" />
+    <Rule Id="SA1602" Action="None" />
+    <Rule Id="SA1633" Action="None" />
+    <Rule Id="SA1636" Action="None" />
+    <Rule Id="SX1309" Action="None" />
+    <Rule Id="SX1309S" Action="None" />
+    <Rule Id="SA1210" Action="None" />
+    <Rule Id="SA1121" Action="Warning" />
+    <Rule Id="SA1124" Action="Warning" />    
+    <Rule Id="SA1308" Action="Error" />
+    <Rule Id="SA1309" Action="Error" />
+  </Rules>
+</RuleSet>

--- a/common.props
+++ b/common.props
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Condition="$(StaticAnalysisEnabled) == 'True'">
+    <WarningLevel>4</WarningLevel>
+    <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
+    <CodeAnalysisRuleSet>$(MSBuildThisFileDirectory)codeanalysis.ruleset</CodeAnalysisRuleSet>
+    <StaticAnalysisEnabled>False</StaticAnalysisEnabled>
+  </PropertyGroup>
+
+  <ItemGroup Condition="$(StaticAnalysisEnabled) == 'True'">
+    <Analyzer Include="$(MSBuildThisFileDirectory)src\packages\StyleCop.Analyzers.1.1.0-beta004/analyzers/dotnet/cs/StyleCop.Analyzers.dll" />
+    <Analyzer Include="$(MSBuildThisFileDirectory)src\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.CSharp.dll" />
+    <Analyzer Include="$(MSBuildThisFileDirectory)src\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\Google.Protobuf.dll" />
+    <Analyzer Include="$(MSBuildThisFileDirectory)src\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.dll" />
+    <AdditionalFiles Include="$(MSBuildThisFileDirectory)stylecop.json">
+      <Link>stylecop.json</Link>
+    </AdditionalFiles>
+  </ItemGroup>
+</Project>

--- a/src/Orchard.Web/Core/Orchard.Core.csproj
+++ b/src/Orchard.Web/Core/Orchard.Core.csproj
@@ -94,6 +94,15 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
   </ItemGroup>
+  <PropertyGroup Condition="'$(StaticAnalysisEnabled)' == 'True'">
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+  </PropertyGroup>
+  <ItemGroup Condition="'$(StaticAnalysisEnabled)' == 'True'">
+    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.1.0-beta004/analyzers/dotnet/cs/StyleCop.Analyzers.dll" />
+    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.CSharp.dll" />
+    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\Google.Protobuf.dll" />
+    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.dll" />
+  </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Controllers\ErrorController.cs" />
     <Compile Include="Common\DateEditor\DateEditorSettings.cs" />

--- a/src/Orchard.Web/Core/Orchard.Core.csproj
+++ b/src/Orchard.Web/Core/Orchard.Core.csproj
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="..\..\..\common.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -35,7 +36,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\..\OrchardBasicCorrectness.ruleset</CodeAnalysisRuleSet>
+    <!-- <CodeAnalysisRuleSet>..\..\OrchardBasicCorrectness.ruleset</CodeAnalysisRuleSet> -->
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>5</LangVersion>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -47,7 +48,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
+    <!-- <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet> -->
     <Prefer32Bit>false</Prefer32Bit>
     <LangVersion>5</LangVersion>
   </PropertyGroup>
@@ -93,15 +94,6 @@
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
-  </ItemGroup>
-  <PropertyGroup Condition="'$(StaticAnalysisEnabled)' == 'True'">
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-  </PropertyGroup>
-  <ItemGroup Condition="'$(StaticAnalysisEnabled)' == 'True'">
-    <Analyzer Include="..\..\packages\StyleCop.Analyzers.1.1.0-beta004/analyzers/dotnet/cs/StyleCop.Analyzers.dll" />
-    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.CSharp.dll" />
-    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\Google.Protobuf.dll" />
-    <Analyzer Include="..\..\packages\SonarAnalyzer.CSharp.6.5.0.3766\analyzers\SonarAnalyzer.dll" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="Common\Controllers\ErrorController.cs" />

--- a/src/Orchard.Web/packages.config
+++ b/src/Orchard.Web/packages.config
@@ -16,4 +16,6 @@
   <package id="Npgsql" version="2.2.3" targetFramework="net452" />
   <package id="Orchard.NuGet.Core" version="1.1.0.0" targetFramework="net452" />
   <package id="Owin" version="1.0" targetFramework="net452" />
+  <package id="SonarAnalyzer.CSharp" version="6.5.0.3766" targetFramework="net452" />
+  <package id="StyleCop.Analyzers" version="1.1.0-beta004" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Added static analysis to Orchard.Core project by:

SonarAnalyzer
StyleCop

Analysis is disabled by default. Run msbuild with StaticAnalysisEnabled parameter set to true in order to enable code analysis during build

```msbuild /p:StaticAnalysisEnabled=true Orchard.sln```

Right now code analysis gives 6356 errors on Orchard.Core project